### PR TITLE
Take restore settings from plugin settings and backup file instead of course restore settings

### DIFF
--- a/classes/restore_controller.php
+++ b/classes/restore_controller.php
@@ -58,6 +58,7 @@ class local_sandbox_restore_controller extends restore_controller {
         ];
 
         $plan = $this->get_plan();
+        $backupsettings = $plan->get_info()->root_settings;
         foreach ($settings as $config => $settingname) {
             if ($plan->setting_exists($settingname)) {
                 $setting = $plan->get_setting($settingname);
@@ -67,7 +68,7 @@ class local_sandbox_restore_controller extends restore_controller {
                 // We can only disable restore settings of the restore plan has enabled them.
                 // Enabling restore settings which are not enabled in the restore plan would let the restore job fail
                 // with the error "Backup is missing XML file".
-                if ($setting->get_value() == true) {
+                if (!empty($backupsettings[$settingname])) {
                     $setting->set_value($value);
                 }
             }


### PR DESCRIPTION
When disabling some default course restore settings e.g. "restore | restore_general_users" but let enabled the sandbox settings e.g. "local_sandbox | restore_general_users", the sandbox plugin doesn't restore this e.g. users.

The plugin should respect the settings in local_sandbox and the settings, how the sandbox course is backuped, independed of the default course restore settings.